### PR TITLE
Add the rust nightly toolchain to the test suite Docker image

### DIFF
--- a/tester/Docker/Dockerfile
+++ b/tester/Docker/Dockerfile
@@ -33,6 +33,7 @@ WORKDIR /home/user
 
 RUN curl https://sh.rustup.rs -sSf > rustup.sh && \
     sh rustup.sh -y && \
+    $HOME/.cargo/bin/rustup toolchain install nightly && \
     rm rustup.sh
 
 RUN git clone https://github.com/myreen/tda283


### PR DESCRIPTION
The rust nightly branch enables unstable features, some of which extend the syntax for pattern matching, which our compiler relies on.

This addition does not change the behaviour of `cargo` or `rustc`, other than allowing `cargo +nightly`-commands. 