### PR TITLE
Add image argument to docker run script

### DIFF
--- a/tester/Docker/README.md
+++ b/tester/Docker/README.md
@@ -22,6 +22,8 @@ OPTIONS:
   -a            expect submission to be archive
   -n            pass --noclean if archive
                 (keeps temporary files, and keeps container alive)
+  -i <image>    custom docker image
+                (default: tda283/tester:latest)
 ```
 
 Example:

--- a/tester/Docker/runtest.sh
+++ b/tester/Docker/runtest.sh
@@ -12,6 +12,8 @@ function helpmsg {
   echo "  -a            expect submission to be archive" >&2
   echo "  -n            pass --noclean if archive" >&2
   echo "                (keeps temporary files, and keeps container alive)" >&2
+  echo "  -i <image>    custom docker image" >&2
+  echo "                (default: tda283/tester:latest)" >&2
 }
 
 if [[ $# -eq 0 ]]; then
@@ -36,7 +38,10 @@ test_llvm=false
 test_x86=false
 test_x64=false
 
-while getopts ":hlyYx:an" opt; do
+# Default docker image, can be overridden with -i
+image="tda283/tester:latest"
+
+while getopts ":hlyYxi:an" opt; do
   case $opt in
     a)
       archive="--archive"
@@ -69,6 +74,9 @@ while getopts ":hlyYx:an" opt; do
     x)
       exts="$OPTARG $exts"
       ;;
+    i)
+      image="$OPTARG"
+      ;;
     \?)
       echo "Invalid option: -$OPTARG"
       helpmsg $0
@@ -85,14 +93,15 @@ echo "Running tests with:" >&2
 echo "  submission:    $submission" >&2
 echo "  backend(s):    $backends" >&2
 echo "  extensions(s): $exts" >&2
+echo "  image:         $image" >&2
 
 base=`basename $submission`
 name="tda283-test-$base"
 
 if [[ -z `docker ps -q -a -f name="$name"` ]]; then
-  cont=`docker run -m 4096M --name "$name" -td -h "$name" tda283/tester:latest`
+  cont=`docker run -m 4096M --name "$name" -td -h "$name" "$image"`
 else
-  cont=`docker run -m 4096M -td -h tda283-test tda283/tester:latest`
+  cont=`docker run -m 4096M -td -h tda283-test "$image"`
 fi
 
 if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
This PR adds an image (`-i`) argument to the test-runner script for docker `tester/Docker/runtest.sh`.

The argument defaults to the previously hardcoded image `tda283/tester:latest` so there should be no breaking changes for any users.

With this change, students will be able to use the same script and toolchain even if they need a custom Dockerfile to build their compiler with another language och generation tool. It will also allow the use of a published docker image so that the user doesn't have to build the image on each computer they will be using.

The changes also introduce the possibility of splitting the currently quite large default image into several language-specific images to reduce download sizes as well as buildtimes. 