### PR TITLE
Allow arguments to -x flag

### DIFF
--- a/tester/Docker/runtest.sh
+++ b/tester/Docker/runtest.sh
@@ -41,7 +41,7 @@ test_x64=false
 # Default docker image, can be overridden with -i
 image="tda283/tester:latest"
 
-while getopts ":hlyYxi:an" opt; do
+while getopts ":hlyYx:i:an" opt; do
   case $opt in
     a)
       archive="--archive"


### PR DESCRIPTION
runtest script was broken in #7 but not noticed until now as the course didn't handle extensions until now.

flag has to be appended with `:` to accept arguemnts