### PR TITLE
Add a riscv toolchain to Dockerfile

### DIFF
--- a/tester/Docker/Dockerfile
+++ b/tester/Docker/Dockerfile
@@ -71,6 +71,28 @@ RUN opam install -y core alcotest
 
 ENV PATH="/home/user/.opam/default/bin:${PATH}"
 
+# Nix needs an user-writable /nix
+USER root
+RUN mkdir /nix
+RUN chown user /nix
+# Install nix
+USER user
+RUN curl -L https://nixos.org/nix/install | sh
+# Manually set up nix variables, since the .profile doesn't get sourced here
+ENV PATH="/home/user/.nix-profile/bin:${PATH}"
+ENV NIX_PATH="${NIX_PATH:+$NIX_PATH:}/home/user/.nix-defexpr/channels"
+ENV NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV NIX_PROFILES="/nix/var/nix/profiles/default /home/user/.nix-profile"
+# Make an helper file that defines riscv cross compilation
+RUN echo 'let hostPkgs = import <nixpkgs> {}; \
+    in import <nixpkgs> \
+    { crossSystem = hostPkgs.lib.systems.examples.riscv64-embedded; }' \
+    > riscv.nix
+# Install x86 spike, cross gcc, and riscv pk
+RUN nix-env -i -A nixpkgs.spike
+RUN nix-env -i -f riscv.nix -A pkgsBuildHost.gcc
+RUN nix-env -i -f riscv.nix -A pkgsHostTarget.riscv-pk
+
 RUN git clone https://github.com/myreen/tda283
 WORKDIR /home/user/tda283/tester
 


### PR DESCRIPTION
The ubuntu repos do not provide a complete enough (static, with simulator)
riscv toolchain.
Instead of building it manually, we first install nix
(https://nixos.org/nix) and then use that to install a cross gcc, spike,
and the proxy kernel.

---

This is a bit unorthodox, but it's the most reliable (and quite fast, since there should be no compiling) way I found to have gcc, spike, and pk in the ubuntu image.

I will shortly make another pr with the testing.py patch.