### PR TITLE
Add timeouts for compilation and execution

### DIFF
--- a/tester/testing.py
+++ b/tester/testing.py
@@ -206,9 +206,12 @@ def run_compiler(exe, src_file, is_good):
                 [exe],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                stdin=infile)
+                stdin=infile,
+                timeout=5)
         stdout = child.stdout.decode("utf-8")
         stderr = child.stderr.decode("utf-8").strip()
+    except subprocess.TimeoutExpired as exc:
+        raise TestingException(str(exc))
     except OSError as exc:
         raise TestingException(
                 "Unable to execute " + exe + " for some reason, " +
@@ -277,8 +280,11 @@ def exec_test(exe, filename, is_good, linker):
                 ["./a.out"],
                 stdin=infile if infile != None else subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                stderr=subprocess.PIPE,
+                timeout=2.5)
         stdout_actual = child.stdout.decode("utf-8")
+    except subprocess.TimeoutExpired as exc:
+        raise TestingException(str(exc))
     except OSError as exc:
         raise TestingException(
                 "Unable to execute ./a.out for some reason, " +


### PR DESCRIPTION
The limits are set to be quite generous, so it shouldn't affect anything that isn't already broken, especially since all the test cases are rather small. In particular, if a test case hangs in the current one, the only way to kill it is sigint or similar, and then you don't get to see what case failed. With timeouts, it can run through the full suite, though it will take a while.

No timeout is set for building the compiler itself though, as that has legit reasons to take a while.