### PR TITLE
Split Docker image into several and add RISC-V toolchain

### DIFF
--- a/tester/Docker/Dockerfile
+++ b/tester/Docker/Dockerfile
@@ -1,40 +1,33 @@
-FROM ubuntu:bionic
+FROM ubuntu:groovy
+
+# For deferring setting up tzdata, avoiding interaction
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
-    build-essential \
-    default-jdk \
-    nasm \
-    llvm \
-    clang \
-    emacs \
-    vim \
-    tmux \
-    curl \
-    git \
-    python3 \
-    ghc \
-    flex \
-    bison \
-    unzip \
-    bubblewrap
+    tzdata build-essential default-jdk nasm llvm clang emacs-nox vim-nox tmux \
+    curl git python3 ghc cabal-install haskell-stack flex bison unzip \
+    bubblewrap locales
 
-RUN curl -sSL https://get.haskellstack.org/ | sh
+# Set up locale. See:
+# https://stackoverflow.com/questions/28405902/how-to-set-the-locale-inside-a-debian-ubuntu-docker-container
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+# Set up tzdata.
+RUN ln -f -s /usr/share/zoneinfo/Europe/Stockholm /etc/localtime
+RUN dpkg-reconfigure tzdata
 
-RUN curl -sL \
-      https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh > \
-      install.sh && \
-      yes '' | sh install.sh && \
-      rm install.sh
+RUN stack upgrade --binary-only
+RUN install -c -m 0755 /root/.local/bin/stack /usr/bin/stack
 
 RUN useradd -ms /bin/bash user
 USER user
 WORKDIR /home/user
 
-RUN curl https://sh.rustup.rs -sSf > rustup.sh && \
-    sh rustup.sh -y && \
-    $HOME/.cargo/bin/rustup toolchain install nightly && \
-    rm rustup.sh
-
+RUN cabal update
+RUN cabal install BNFC-2.8.4 alex happy
+RUN stack update
 
 RUN mkdir -p classpath/JLex/JLex
 RUN cd classpath/JLex/JLex && \
@@ -49,27 +42,10 @@ RUN cd classpath/CUP && \
 RUN mkdir -p subm
 
 ENV PATH="/home/user/.local/bin:${PATH}"
-ENV PATH="/home/user/.cargo/bin:${PATH}"
+ENV PATH="/home/user/.cabal/bin:${PATH}"
 ENV CLASSPATH="/home/user/classpath/JLex:${CLASSPATH}"
 ENV CLASSPATH="/home/user/classpath/CUP/java-cup-11b-runtime.jar:${CLASSPATH}"
 ENV CLASSPATH="/home/user/classpath/CUP/java-cup-11b.jar:${CLASSPATH}"
-
-RUN stack install \
-    array \
-    base \
-    containers \
-    filepath \
-    microlens-platform \
-    mtl \
-    process
-RUN stack install BNFC
-
-RUN opam init -a -y --disable-sandboxing --dot-profile=~/.bashrc
-RUN sh /home/user/.opam/opam-init/init.sh
-RUN opam install dune
-RUN opam install -y core alcotest
-
-ENV PATH="/home/user/.opam/default/bin:${PATH}"
 
 RUN git clone https://github.com/myreen/tda283
 WORKDIR /home/user/tda283/tester

--- a/tester/Docker/Dockerfile-ocaml
+++ b/tester/Docker/Dockerfile-ocaml
@@ -1,0 +1,21 @@
+# vim: ft=dockerfile
+FROM tda283/tester
+
+USER root
+
+RUN curl -sL \
+      https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh > \
+      install.sh && \
+      yes '' | sh install.sh && \
+      rm install.sh
+
+USER user
+
+RUN opam init -a -y --disable-sandboxing --dot-profile=~/.bashrc
+RUN sh /home/user/.opam/opam-init/init.sh
+RUN opam install dune
+RUN opam install -y core alcotest
+
+ENV PATH="/home/user/.opam/default/bin:${PATH}"
+WORKDIR /home/user/tda283/tester
+CMD /bin/bash

--- a/tester/Docker/Dockerfile-riscv
+++ b/tester/Docker/Dockerfile-riscv
@@ -1,0 +1,27 @@
+# vim: ft=dockerfile
+FROM tda283/tester
+
+# Nix needs an user-writable /nix
+USER root
+RUN mkdir /nix
+RUN chown user /nix
+# Install nix
+USER user
+RUN curl -L https://nixos.org/nix/install | sh
+# Manually set up nix variables, since the .profile doesn't get sourced here
+ENV PATH="/home/user/.nix-profile/bin:${PATH}"
+ENV NIX_PATH="${NIX_PATH:+$NIX_PATH:}/home/user/.nix-defexpr/channels"
+ENV NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV NIX_PROFILES="/nix/var/nix/profiles/default /home/user/.nix-profile"
+# Make an helper file that defines riscv cross compilation
+RUN echo 'let hostPkgs = import <nixpkgs> {}; \
+    in import <nixpkgs> \
+    { crossSystem = hostPkgs.lib.systems.examples.riscv64-embedded; }' \
+    > riscv.nix
+# Install x86 spike, cross gcc, and riscv pk
+RUN nix-env -i -A nixpkgs.spike
+RUN nix-env -i -f riscv.nix -A pkgsBuildHost.gcc
+RUN nix-env -i -f riscv.nix -A pkgsHostTarget.riscv-pk
+
+WORKDIR /home/user/tda283/tester
+CMD /bin/bash

--- a/tester/Docker/Dockerfile-rust
+++ b/tester/Docker/Dockerfile-rust
@@ -1,0 +1,11 @@
+# vim: ft=dockerfile
+FROM tda283/tester
+
+RUN curl https://sh.rustup.rs -sSf > rustup.sh && \
+    sh rustup.sh -y && \
+    $HOME/.cargo/bin/rustup toolchain install nightly && \
+    rm rustup.sh
+
+ENV PATH="/home/user/.cargo/bin:${PATH}"
+WORKDIR /home/user/tda283/tester
+CMD /bin/bash

--- a/tester/Docker/Makefile
+++ b/tester/Docker/Makefile
@@ -4,7 +4,7 @@ VERSION ?= latest
 CONTAINER_NAME ?= tester
 CONTAINER_INSTANCE ?= default
 
-.PHONY: build shell dist
+.PHONY: build shell dist rust ocaml riscv
 
 default: build
 
@@ -16,6 +16,9 @@ rust: Dockerfile-rust
 
 ocaml: Dockerfile-ocaml
 	docker build -m 4096M -t $(NS)/$(IMAGE)-ocaml:$(VERSION) -f $< .
+
+riscv: Dockerfile-riscv
+	docker build -m 4096M -t $(NS)/$(IMAGE)-riscv:$(VERSION) -f $< .
 
 shell:
 	docker run -m 4096M --rm --name $(CONTAINER_NAME)-$(CONTAINER_INSTANCE) \

--- a/tester/Docker/Makefile
+++ b/tester/Docker/Makefile
@@ -4,10 +4,12 @@ VERSION ?= latest
 CONTAINER_NAME ?= tester
 CONTAINER_INSTANCE ?= default
 
-.PHONY: shell build
+.PHONY: build shell dist
+
+default: build
 
 build: Dockerfile
-	docker build -m 4096M -t $(NS)/$(IMAGE):$(VERSION) -f Dockerfile .
+	docker build -m 4096M -t $(NS)/$(IMAGE):$(VERSION) -f $< .
 
 shell:
 	docker run -m 4096M --rm --name $(CONTAINER_NAME)-$(CONTAINER_INSTANCE) \
@@ -15,7 +17,6 @@ shell:
 
 dist: tda283-docker.tar.gz
 
-tda283-docker.tar.gz: Makefile Dockerfile runtest.sh README.md
+tda283-docker.tar.gz: Makefile Dockerfile* runtest.sh README.md
 	tar cvzf $@ $^
 
-default: build

--- a/tester/Docker/Makefile
+++ b/tester/Docker/Makefile
@@ -11,6 +11,12 @@ default: build
 build: Dockerfile
 	docker build -m 4096M -t $(NS)/$(IMAGE):$(VERSION) -f $< .
 
+rust: Dockerfile-rust
+	docker build -m 4096M -t $(NS)/$(IMAGE)-rust:$(VERSION) -f $< .
+
+ocaml: Dockerfile-ocaml
+	docker build -m 4096M -t $(NS)/$(IMAGE)-ocaml:$(VERSION) -f $< .
+
 shell:
 	docker run -m 4096M --rm --name $(CONTAINER_NAME)-$(CONTAINER_INSTANCE) \
 	  -i -t $(NS)/$(IMAGE):$(VERSION) /bin/bash

--- a/tester/Docker/README.md
+++ b/tester/Docker/README.md
@@ -11,7 +11,7 @@ INSTRUCTIONS
 3. Run the test script with `bash runtest.sh`:
 
 ```
-USAGE: runtest.sh <submission> [options]
+USAGE: runtest.sh [options] [--] <submission>
 OPTIONS:
   -h            this message
   -l            test LLVM backend

--- a/tester/Docker/runtest.sh
+++ b/tester/Docker/runtest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function helpmsg {
-  echo "USAGE: $1 <submission> [options]" >&2
+  echo "USAGE: $1 [options] [--] <submission>" >&2
   echo "OPTIONS:" >&2
   echo "  -h            this message" >&2
   echo "  -l            test LLVM backend" >&2
@@ -18,19 +18,6 @@ if [[ $# -eq 0 ]]; then
   helpmsg $0
   exit 1
 fi
-
-submission="$1"
-
-if [[ ! -d "$submission" ]]; then
-  if [[ ! -f "$submission" ]]; then
-    echo "$1 is not a file or directory" >&2
-    exit 1
-  fi
-fi
-
-shift 1
-
-OPTIND=1
 
 test_llvm=false
 test_x86=false
@@ -80,6 +67,17 @@ while getopts ":hlyYxi:n" opt; do
   esac
 done
 
+shift $(($OPTIND - 1))
+
+submission="$1"
+
+if [[ ! -d "$submission" ]]; then
+  if [[ ! -f "$submission" ]]; then
+    echo "$1 is not a file or directory" >&2
+    exit 1
+  fi
+fi
+
 if [[ -n "$exts" ]]; then
   exts="-x $exts"
 fi
@@ -100,7 +98,7 @@ else
 fi
 
 if [[ $? -ne 0 ]]; then
-  echo "Failed to create contained" >&2
+  echo "Failed to create container" >&2
 fi
 
 name=`docker ps --filter id="$cont" --format '{{.Names}}'`


### PR DESCRIPTION
- Fix some issues in runtest.sh
- Make the base Docker image a bit lighter by stripping out once-used tools (rust nightly, ocaml, dune) and some unused Haskell/stack deps
- Put the Ocaml/rust stuff into their own Docker images (use the -i flag from 77916ee to pick which one to use)
- Include the RISC-V toolchain used last year by @fgaz (see #10)