### PR TITLE
Added zig docker image

### DIFF
--- a/tester/Docker/Dockerfile-zig
+++ b/tester/Docker/Dockerfile-zig
@@ -1,0 +1,16 @@
+# vim: ft=dockerfile
+FROM tda283/tester
+
+ARG os="linux"
+ARG arch="x86_64"
+ARG version="0.8.0-dev.1548+0d96a284e"
+
+ARG dir="zig-$os-$arch-$version"
+ARG file="$dir.tar.xz"
+
+WORKDIR /home/user/
+RUN echo $file && curl -O "https://ziglang.org/builds/$file" && tar -xf "$file" && rm "$file"
+ENV PATH="/home/user/$dir/:${PATH}"
+
+WORKDIR /home/user/tda283/tester
+CMD /bin/bash

--- a/tester/Docker/Makefile
+++ b/tester/Docker/Makefile
@@ -4,7 +4,7 @@ VERSION ?= latest
 CONTAINER_NAME ?= tester
 CONTAINER_INSTANCE ?= default
 
-.PHONY: build shell dist rust ocaml riscv
+.PHONY: build shell dist rust ocaml riscv zig
 
 default: build
 
@@ -19,6 +19,9 @@ ocaml: Dockerfile-ocaml
 
 riscv: Dockerfile-riscv
 	docker build -m 4096M -t $(NS)/$(IMAGE):riscv -f $< .
+
+zig: Dockerfile-zig
+	docker build -m 4096M -t $(NS)/$(IMAGE):zig -f $< .
 
 shell:
 	docker run -m 4096M --rm --name $(CONTAINER_NAME)-$(CONTAINER_INSTANCE) \


### PR DESCRIPTION
Added zig docker image to run the testsuite on a JavaLette compiler written in [Zig](https://ziglang.org/).

I have created a dummy submission [here](https://github.com/AntonHakansson/JavaLette).
Under releases you can find a dummy submission that you can test and confirm that it works as expected.

On my end the tests seems to be running fine with the exception that the docker instance quits out early(?).
However, this might be expected as I don't output anything other than `OK` to `stderr`.

Also relevant: https://chalmers.instructure.com/courses/13383/discussion_topics/60846