### PR TITLE
Fix bad tests with `void main`

### DIFF
--- a/tester/testsuite/bad/bad028.jl
+++ b/tester/testsuite/bad/bad028.jl
@@ -1,3 +1,5 @@
-void main(){
+// cannot define String variable
+int main(){
     String x;
+    return 0;
 }

--- a/tester/testsuite/bad/bad067.jl
+++ b/tester/testsuite/bad/bad067.jl
@@ -1,0 +1,4 @@
+// return type must be int
+void main() {
+    return 0;
+}

--- a/tester/testsuite/extensions/arrays1/bad/bad001.jl
+++ b/tester/testsuite/extensions/arrays1/bad/bad001.jl
@@ -1,6 +1,7 @@
 /* index not of integer type */
 
-void main() {
+int main() {
 	int[] array = new int[10];
 	printInt(array["x"]);
+	return 0;
 }

--- a/tester/testsuite/extensions/arrays1/bad/bad002.jl
+++ b/tester/testsuite/extensions/arrays1/bad/bad002.jl
@@ -1,5 +1,6 @@
 /* length not of integer type */
 
-void main() {
+int main() {
 	int[] array = new int["x"];
+	return 0;
 }

--- a/tester/testsuite/extensions/arrays2/bad/bad001.jl
+++ b/tester/testsuite/extensions/arrays2/bad/bad001.jl
@@ -1,6 +1,7 @@
 /* invalid depth when assigning */
 
-void main() {
+int main() {
 	int[] array = new int[10][10];
 	printInt(array[0][0]);
+	return 0;
 }

--- a/tester/testsuite/extensions/arrays2/bad/bad002.jl
+++ b/tester/testsuite/extensions/arrays2/bad/bad002.jl
@@ -1,6 +1,7 @@
 /* invalid depth when indexing */
 
-void main() {
+int main() {
 	int[][] array = new int[10][10];
 	printInt(array[0][0][0]);
+	return 0;
 }

--- a/tester/testsuite/extensions/objects1/bad/bad005.jl
+++ b/tester/testsuite/extensions/objects1/bad/bad005.jl
@@ -1,5 +1,6 @@
 /* new undeclared class */
 
-void main() {
+int main() {
 	new Point;
+	return 0;
 }

--- a/tester/testsuite/extensions/pointers/bad/bad003.jl
+++ b/tester/testsuite/extensions/pointers/bad/bad003.jl
@@ -7,7 +7,8 @@ struct Point2 {
 	int y;
 };
 
-void main() {
+int main() {
 	Point point = new Point2;
 	point->z = 1;
+	return 0;
 }


### PR DESCRIPTION
The return type of `main` must be `int` [*](https://github.com/myreen/tda283/blob/master/project/javalette.md#program-structure). Some bad test cases meant to test arrays or structs have `void main`.

I have fixed the return types and added `return 0` statements.