### PR TITLE
Add parentheses around `new A`

### DIFF
--- a/tester/testsuite/extensions/pointers/syntax.jl
+++ b/tester/testsuite/extensions/pointers/syntax.jl
@@ -6,7 +6,7 @@ struct A {
 };
 
 int main () {
-    printInt(new A->a);
-    new A->b = new A;
+    printInt((new A)->a);
+    (new A)->b = new A;
     return 0;
 }


### PR DESCRIPTION
Added parentheses to correctly parse `new A -> a`.

It should parse as `(new A) -> a` but defining the precedence among following forms can be problematic.

* array creation
* array indexing
* struct creation (`new Foo`)
* pointer dereferencing (`foo->x`)